### PR TITLE
azurerm pinned 3.71.x, random pinned 3.5.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,10 +36,10 @@ repos:
       - --args=terraform --version '>= 1.5.6'
     - id: tfupdate
       args:
-      - --args=provider --version '3.71.0' azurerm
+      - --args=provider --version '~> 3.71.0' azurerm
     - id: tfupdate
       args:
-      - --args=provider --version '3.5.1' random
+      - --args=provider --version '~> 3.5.1' random
     # - id: infracost_breakdown
     #   args:
     #     - --args=--path=.

--- a/providers.tf
+++ b/providers.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.71.0"
+      version = "~> 3.71.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.5.1"
+      version = "~> 3.5.1"
     }
   }
 }


### PR DESCRIPTION
Housekeeping to properly pin providers to patch releases only. 

- Updates pre-commit to pin random provider at ~> 3.5.x
- Updates pre-commit to pin azurerm provider at ~> 3.71.x
